### PR TITLE
Benchmark refactor

### DIFF
--- a/cpp/src/core/structures/waypoint.hpp
+++ b/cpp/src/core/structures/waypoint.hpp
@@ -299,12 +299,12 @@ struct TimeWindow final {
         return (start+end)/2;
     }
 
-    bool contains(const double time) const {
-        return time >= start && time < end;
+    bool contains(double time) const {
+        return start <= time && time < end;
     }
 
-    bool is_within(const TimeWindow& time_window) const {
-        return start <= time_window.start && end < time_window.end;
+    bool contains(const TimeWindow &time_window) const {
+        return start <= time_window.start && time_window.end < end;
     }
 };
 

--- a/cpp/src/python_interface.cpp
+++ b/cpp/src/python_interface.cpp
@@ -98,6 +98,10 @@ PYBIND11_MODULE(uav_planning, m) {
                  py::arg("start"), py::arg("end"))
             .def_readonly("start", &TimeWindow::start)
             .def_readonly("end", &TimeWindow::end)
+            .def("contains", (bool (TimeWindow::*)(double time) const)&TimeWindow::contains,
+                 py::arg("time"))
+            .def("contains", (bool (TimeWindow::*)(const TimeWindow &) const)&TimeWindow::contains,
+                 py::arg("time_window"))
             .def("__repr__",
                  [](const TimeWindow &tw) {
                      std::stringstream repr;
@@ -162,7 +166,7 @@ PYBIND11_MODULE(uav_planning, m) {
             .def(py::init<Position, double>(),
                  py::arg("point"), py::arg("time"))
             .def_readonly("pt", &PositionTime::pt)
-            .def_readonly("y", &PositionTime::time)
+            .def_readonly("time", &PositionTime::time)
             .def("__repr__",
                  [](const PositionTime &p) {
                      std::stringstream repr;
@@ -178,7 +182,7 @@ PYBIND11_MODULE(uav_planning, m) {
             .def(py::init<Position3d, double>(),
                  py::arg("point"), py::arg("time"))
             .def_readonly("pt", &Position3dTime::pt)
-            .def_readonly("y", &Position3dTime::time)
+            .def_readonly("time", &Position3dTime::time)
             .def("__repr__",
                  [](const Position3dTime &p) {
                      std::stringstream repr;
@@ -257,7 +261,10 @@ PYBIND11_MODULE(uav_planning, m) {
             .def("utility", &Plan::utility)
             .def("duration", &Plan::duration)
             .def_readonly("firedata", &Plan::firedata)
-            .def("observations", &Plan::observations);
+            .def_readonly("time_window", &Plan::time_window)
+            .def("observations", (vector<PositionTime> (Plan::*)() const) &Plan::observations)
+            .def("observations", (vector<PositionTime> (Plan::*)(const TimeWindow &) const) &Plan::observations,
+                 py::arg("tw"));
 
     py::class_<SearchResult>(m, "SearchResult")
             .def("initial_plan", &SearchResult::initial)

--- a/cpp/src/vns/neighborhoods/insertions.hpp
+++ b/cpp/src/vns/neighborhoods/insertions.hpp
@@ -94,7 +94,7 @@ private:
 
         /** Select a random point in the pending list */
         const size_t index = rand(0, p->possible_observations.size());
-        const Point3dTimeWindow pt = p->possible_observations[index];
+        const PointTimeWindow pt = p->possible_observations[index];
 
         /** Pick an angle randomly */
         const double random_angle = drand(0, 2*M_PI);

--- a/cpp/src/vns/plan.hpp
+++ b/cpp/src/vns/plan.hpp
@@ -59,8 +59,8 @@ struct Plan {
                 if (time_window.start <= t && t <= time_window.end) {
                     Cell c{x, y};
                     possible_observations.push_back(
-                            //FIXME: This shouldn't be 3D
-                            PointTimeWindow{firedata->ignitions.as_position(c), {firedata->ignitions(c), firedata->traversal_end(c)}});
+                            PointTimeWindow{firedata->ignitions.as_position(c),
+                                            {firedata->ignitions(c), firedata->traversal_end(c)}});
                 }
             }
         }

--- a/cpp/src/vns/plan.hpp
+++ b/cpp/src/vns/plan.hpp
@@ -43,13 +43,11 @@ struct Plan {
     Trajectories core;
     shared_ptr<FireData> firedata;
     vector<PointTimeWindow> possible_observations;
-    vector<PointTimeWindow> actual_observations;
 
     Plan(const Plan& plan) = default;
 
-    Plan(vector<TrajectoryConfig> traj_confs, shared_ptr<FireData> fire_data, TimeWindow tw,
-         vector<PointTimeWindow> actual_observations)
-            : time_window(tw), core(traj_confs), firedata(fire_data), actual_observations(actual_observations)
+    Plan(vector<TrajectoryConfig> traj_confs, shared_ptr<FireData> fire_data, TimeWindow tw)
+            : time_window(tw), core(traj_confs), firedata(fire_data)
     {
         for(auto conf : traj_confs) {
             ASSERT(conf.start_time >= time_window.start && conf.start_time <= time_window.end);
@@ -67,10 +65,6 @@ struct Plan {
             }
         }
     }
-
-    Plan(vector<TrajectoryConfig> traj_confs, shared_ptr<FireData> fire_data, TimeWindow tw)
-            : Plan(traj_confs, fire_data, tw, vector<PointTimeWindow>({}))
-    { }
 
     json metadata() const {
         json j;

--- a/python/fire_rs/firemodel/demo_propagation.py
+++ b/python/fire_rs/firemodel/demo_propagation.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2017, CNRS-LAAS
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Simple demo showcasing how to use the fire propagation module and how to display the result"""
+import matplotlib.cm
+import matplotlib.pyplot as plt
+
+from fire_rs.firemodel import propagation
+from fire_rs.geodata.display import GeoDataDisplay, plot_ignition_point
+from fire_rs.geodata.geo_data import TimedPoint
+
+if __name__ == "__main__":
+    area = ((480060.0, 485060.0), (6210074.0, 6215074.0))
+    env = propagation.Environment(area, wind_speed=5., wind_dir=0.)
+    ignition_point = TimedPoint(area[0][0] + 1000.0, area[1][0] + 2000.0, 0)
+    fire = propagation.propagate_from_points(env, ignition_point, 9000)
+
+    gdd = GeoDataDisplay.pyplot_figure(env.raster.combine(fire.ignitions().slice(["ignition"])))
+    gdd.draw_elevation_shade(with_colorbar=False, cmap=matplotlib.cm.terrain)
+    gdd.draw_wind_quiver()
+    gdd.draw_ignition_contour(with_labels=True, cmap=matplotlib.cm.plasma)
+    gdd.draw_ignition_points(ignition_point)
+    plt.plot(block=True)

--- a/python/fire_rs/firemodel/propagation.py
+++ b/python/fire_rs/firemodel/propagation.py
@@ -65,6 +65,7 @@ class Environment:
         self._clustering = None
 
     @property
+    @deprecated
     def clustering(self):
         if self._clustering is None:
             base_for_clustering = self.raster.slice(['wind_angle', 'wind_velocity', 'fuel', 'moisture'])
@@ -215,6 +216,7 @@ class FirePropagation:
                     d[x + dx, y + dy][2] = y
                     self._push_to_propagation_queue(x + dx, y + dy, t + dt)
 
+    @deprecated
     def information_matrix(self):
         d = self.prop_data.clone(fill_value=0, dtype=[('env_cluster', 'int32'), ('propagation_angle', 'float64'),
                                                       ('propagation_speed', 'float64'), ('error_on_speed', 'float64')])
@@ -231,6 +233,7 @@ class FirePropagation:
         cc = cluster_multi_layer(c, {'propagation_angle': 0.1}, already_clustered=['env_cluster'], cluster_layer_name='information_clustering')
         return d.combine(cc)
 
+    @deprecated
     def information_gain(self, x, y):
         def pred(x, y):
             return self.prop_data.data[x, y][1], self.prop_data.data[x, y][2]

--- a/python/fire_rs/firemodel/propagation.py
+++ b/python/fire_rs/firemodel/propagation.py
@@ -49,15 +49,18 @@ class Environment:
         """Abstract class providing access to the main properties of the environment
 
         :param area: ((x_min, x_max), (y_min, y_max))
-        :param wind_speed: wind speed in km/h
-        :param wind_dir: wind direction in radians
+        :param wind_speed: mean wind speed in km/h
+        :param wind_dir: mean wind direction in radians
         """
-        world = World()
-        elevation = world.get_elevation(area)
-        slope = world.get_slope(area)
-        wind = world.get_wind(area, domain_average=(wind_speed, wind_dir))
+        self._wind_speed = wind_speed  # type: float
+        self._wind_dir = wind_dir  # type: float
+        self._area = area  # type: ((float, float), (float, float))
+        self._world = World()  # type: World
+        elevation = self._world.get_elevation(area)
+        slope = self._world.get_slope(area)
+        wind = self._world.get_wind(area, domain_average=(wind_speed, wind_dir))
         moisture = slope.clone(fill_value=env.get_moisture_scenario_id('D1L1'), dtype=[('moisture', 'int32')])
-        fuel = world.get_fuel_type(area)
+        fuel = self._world.get_fuel_type(area)
         self.raster = slope.combine(wind).combine(moisture).combine(fuel).combine(elevation)
         self._clustering = None
 
@@ -69,6 +72,11 @@ class Environment:
                                                    err_by_layer={'wind_angle': 0.2, 'wind_velocity': 2},
                                                    already_clustered=['fuel', 'moisture'])
         return self._clustering
+
+    def update_area_wind(self, wind_speed, wind_dir):
+        new_wind = self._world.get_wind(self._area, domain_average=(wind_speed, wind_dir))
+        self.raster['wind_velocity'] = new_wind['wind_velocity']
+        self.raster['wind_direction'] = new_wind['wind_direction']
 
     def get_fuel_type(self, x, y):
         """Returns the fuel type (e.g. 'SH5') in (x,y)"""

--- a/python/fire_rs/geodata/display.py
+++ b/python/fire_rs/geodata/display.py
@@ -141,9 +141,9 @@ class GeoDataDisplay:
         figure, axis = get_pyplot_figure_and_axis()
         return cls(figure, axis, geodata)
 
-    def draw_elevation_shade(self, with_colorbar=True, **kwargs):
+    def draw_elevation_shade(self, with_colorbar=True, layer='elevation', **kwargs):
         shade = plot_elevation_shade(self.axis, self._x_mesh, self._y_mesh,
-                                     self._geodata['elevation'].T[::-1, ...],
+                                     self._geodata[layer].T[::-1, ...],
                                      dx=self._geodata.cell_width, dy=self._geodata.cell_height,
                                      image_scale=self._image_scale, **kwargs)
         self._drawings.append(shade)
@@ -164,9 +164,9 @@ class GeoDataDisplay:
         self._drawings.append(plot_wind_quiver(self.axis, *np.meshgrid(self._x_ticks[::10], self._y_ticks[::10]),
                                                WX[::10, ::10], WY[::10, ::10], **kwargs))
 
-    def draw_ignition_contour(self, with_labels=True, **kwargs):
+    def draw_ignition_contour(self, with_labels=True, layer='ignition', **kwargs):
         # mask all cells whose ignition has not been computed
-        igni = np.array(self._geodata['ignition'])
+        igni = np.array(self._geodata[layer])
         igni[igni >= np.finfo(np.float64).max] = np.nan
 
         # plot fire front with contour lines in minutes
@@ -178,9 +178,9 @@ class GeoDataDisplay:
     def _add_ignition_contour_labels(self, **kwargs):
         self.axis.clabel(self._drawings[-1], inline=True, fontsize='smaller', inline_spacing=1, linewidth=2, fmt='%.0f')
 
-    def draw_ignition_shade(self, with_colorbar=True, **kwargs):
+    def draw_ignition_shade(self, with_colorbar=True, layer='ignition', **kwargs):
         # mask all cells whose ignition has not been computed
-        igni = np.array(self._geodata['ignition'])
+        igni = np.array(self._geodata[layer])
         igni[igni >= np.finfo(np.float64).max] = np.nan
 
         shade = plot_ignition_shade(self.axis, self._x_mesh, self._y_mesh, np.around(igni.T[::-1, ...]/60., 1),

--- a/python/fire_rs/geodata/display.py
+++ b/python/fire_rs/geodata/display.py
@@ -77,11 +77,13 @@ def plot_ignition_contour(ax, x, y, ignition_times, nfronts=None, **kwargs):
     if not nfronts:
         lim = (np.nanmin(ignition_times), np.nanmax(ignition_times))
         nfronts = int(np.clip(int((lim[1]-lim[0])/60)*10, 3, 20))
-    return ax.contour(x, y, ignition_times, nfronts, cmap=matplotlib.cm.gist_rainbow, **kwargs)
+    if not 'cmap' in kwargs:
+        kwargs['cmap'] = matplotlib.cm.gist_rainbow
+    return ax.contour(x, y, ignition_times, nfronts, **kwargs)
 
 
 def plot_elevation_contour(ax, x, y, z, **kwargs):
-    contour = ax.contour(x, y, z, 15, cmap=matplotlib.cm.gist_earth)
+    contour = ax.contour(x, y, z, 15, cmap=kwargs.get('cmap', matplotlib.cm.gist_earth))
     # labels = plt.clabel(contour, inline=1, fontsize=10)
     return contour
 
@@ -92,9 +94,10 @@ def plot_elevation_shade(ax, x, y, z, dx=25, dy=25, image_scale=None, **kwargs):
         image_scale = (x[0][0], x[0][x.shape[0] - 1], y[0][0], y[y.shape[0] - 1][0])
     ls = LightSource(azdeg=315, altdeg=35)
     ax.imshow(ls.hillshade(z, vert_exag=1, dx=dx, dy=dy), extent=image_scale, cmap='gray')
-    return ax.imshow(ls.shade(z, cmap=matplotlib.cm.gist_earth, blend_mode='overlay', vert_exag=1, dx=dx, dy=dy,
-                              vmin=cbar_lim[0], vmax=cbar_lim[1]),
-                     extent=image_scale, vmin=cbar_lim[0], vmax=cbar_lim[1], cmap=matplotlib.cm.gist_earth)
+    return ax.imshow(ls.shade(z, cmap=kwargs.get('cmap', matplotlib.cm.gist_earth), blend_mode='overlay', vert_exag=1,
+                              dx=dx, dy=dy, vmin=cbar_lim[0], vmax=cbar_lim[1]),
+                     extent=image_scale, vmin=cbar_lim[0], vmax=cbar_lim[1],
+                     cmap=kwargs.get('cmap', matplotlib.cm.gist_earth))
 
 
 def plot_wind_flow(ax, x, y, wx, wy, wvel, **kwargs):
@@ -165,8 +168,7 @@ class GeoDataDisplay:
         igni[igni >= np.finfo(np.float64).max] = np.nan
 
         # plot fire front with contour lines in minutes
-        self._drawings.append(plot_ignition_contour(self.axis, self._x_ticks, self._y_ticks, igni.T / 60.),
-                              **kwargs)
+        self._drawings.append(plot_ignition_contour(self.axis, self._x_ticks, self._y_ticks, igni.T / 60., **kwargs))
 
         if with_labels:
             self._add_ignition_contour_labels()
@@ -194,10 +196,10 @@ class GeoDataDisplay:
 
 # "DisplayExtension" classes attach new member functions to a GeoDataDisplay to make it able to display other data
 class DisplayExtension(metaclass=abc.ABCMeta):
-    RASTER_LAYER = 0
-    RASTER_OVERLAY_LAYER = 100
-    TRAJECTORY_LAYER = 200
-    TRAJECTORY_OVERLAY_LAYER = 300
+    BACKGROUND_LAYER = 0
+    BACKGROUND_OVERLAY_LAYER = 100
+    FOREGROUND_LAYER = 200
+    FOREGROUND_OVERLAY_LAYER = 300
 
     @abc.abstractmethod
     def extend(self, geodatadisplay):

--- a/python/fire_rs/geodata/display.py
+++ b/python/fire_rs/geodata/display.py
@@ -69,8 +69,10 @@ def plot_ignition_shade(ax, x, y, ignition_times, dx=25, dy=25, image_scale=None
     cbar_lim = (np.nanmin(ignition_times), np.nanmax(ignition_times))
     if not image_scale:
         image_scale = (x[0][0], x[0][x.shape[0] - 1], y[0][0], y[y.shape[0] - 1][0])
+    if not 'cmap' in kwargs:
+        kwargs['cmap'] = matplotlib.cm.gist_heat
     return ax.imshow(ignition_times, extent=image_scale, vmin=cbar_lim[0], vmax=cbar_lim[1],
-                     cmap=matplotlib.cm.gist_heat, **kwargs)
+                     **kwargs)
 
 
 def plot_ignition_contour(ax, x, y, ignition_times, nfronts=None, **kwargs):

--- a/python/fire_rs/geodata/display.py
+++ b/python/fire_rs/geodata/display.py
@@ -99,8 +99,7 @@ def plot_elevation_shade(ax, x, y, z, dx=25, dy=25, image_scale=None, **kwargs):
     return ax.imshow(ls.shade(z, cmap=kwargs.get('cmap', matplotlib.cm.gist_earth), blend_mode='overlay', vert_exag=1,
                               dx=dx, dy=dy, vmin=cbar_lim[0], vmax=cbar_lim[1]),
                      extent=image_scale, vmin=cbar_lim[0], vmax=cbar_lim[1],
-                     cmap=kwargs.get('cmap', matplotlib.cm.gist_earth))
-
+                     cmap=kwargs.get('cmap', matplotlib.cm.gist_earth), interpolation='bilinear')
 
 def plot_wind_flow(ax, x, y, wx, wy, wvel, **kwargs):
     return ax.streamplot(x, y, wx, wy, density=1, linewidth=1, color='dimgrey')

--- a/python/fire_rs/geodata/geo_data.py
+++ b/python/fire_rs/geodata/geo_data.py
@@ -82,7 +82,14 @@ class GeoData:
 
     @classmethod
     def zeros_like(cls, other: 'GeoData'):
-        return cls(np.zeros_like(other.data), other.x_offset, other.y_offset, other.cell_width, other.cell_height)
+        return cls(np.zeros_like(other.data), other.x_offset, other.y_offset,
+                   other.cell_width, other.cell_height)
+
+    @classmethod
+    def full_like(cls, other: 'GeoData', fill_value):
+        return cls(np.full_like(other.data, fill_value), other.x_offset, other.y_offset,
+                   other.cell_width, other.cell_height)
+
 
     def __contains__(self, coordinates):
         (x, y) = coordinates

--- a/python/fire_rs/geodata/geo_data.py
+++ b/python/fire_rs/geodata/geo_data.py
@@ -22,7 +22,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from collections import namedtuple
+from collections import namedtuple, Sequence
 from functools import reduce
 
 import gdal
@@ -79,6 +79,10 @@ class GeoData:
         ar = np.array(lraster.as_numpy(), dtype=[(layer_name, 'int64')])
         gd = GeoData(ar, lraster.x_offset, lraster.y_offset, lraster.cell_width, lraster.cell_width)
         return gd
+
+    @classmethod
+    def zeros_like(cls, other: 'GeoData'):
+        return cls(np.zeros_like(other.data), other.x_offset, other.y_offset, other.cell_width, other.cell_height)
 
     def __contains__(self, coordinates):
         (x, y) = coordinates

--- a/python/fire_rs/planning/benchmark.py
+++ b/python/fire_rs/planning/benchmark.py
@@ -361,7 +361,7 @@ scenario_factory_funcs = {'default': generate_scenario,
 
 
 vns_configurations = {
-    "base": {
+    "demo": {
         "max_restarts": 5,
         "neighborhoods": [
             {"name": "dubins-opt",
@@ -374,44 +374,6 @@ vns_configurations = {
                 "max_trials": 50,
                 "select_arbitrary_trajectory": False,
                 "select_arbitrary_position": False}
-        ]
-    },
-    "with_smoothing": {
-        "max_restarts": 5,
-        "neighborhoods": [
-            {"name": "trajectory-smoothing",
-                "max_trials": 10},
-            {"name": "dubins-opt",
-                "max_trials": 10,
-                "generators": [
-                    {"name": "MeanOrientationChangeGenerator"},
-                    {"name": "RandomOrientationChangeGenerator"},
-                    {"name": "FlipOrientationChangeGenerator"}]},
-            {"name": "one-insert",
-                "max_trials": 50,
-                "select_arbitrary_trajectory": False,
-                "select_arbitrary_position": False}]
-    },
-    "full": {
-        "max_restarts": 5,
-        "neighborhoods": [
-            {"name": "dubins-opt",
-                "max_trials": 10,
-                "generators": [
-                    {"name": "RandomOrientationChangeGenerator"},
-                    {"name": "FlipOrientationChangeGenerator"}]},
-            {"name": "one-insert",
-                "max_trials": 50,
-                "select_arbitrary_trajectory": False,
-                "select_arbitrary_position": False},
-            {"name": "one-insert",
-                "max_trials": 200,
-                "select_arbitrary_trajectory": True,
-                "select_arbitrary_position": False},
-            {"name": "one-insert",
-                "max_trials": 200,
-                "select_arbitrary_trajectory": True,
-                "select_arbitrary_position": True}
         ]
     }
 }
@@ -465,7 +427,7 @@ def main():
                         help="Load VNS configurations from a JSON file")
     parser.add_argument("--vns",
                         help="Select a VNS configuration, among the default ones or from the file specified in --vns-conf.",
-                        default='base')
+                        default='demo')
     parser.add_argument("--elevation",
                         help="Source of elevation considered by the planning algorithm",
                         choices=['flat', 'dem', 'discrete'],

--- a/python/fire_rs/planning/benchmark.py
+++ b/python/fire_rs/planning/benchmark.py
@@ -500,6 +500,7 @@ def main():
         matplotlib.rcParams['text.usetex'] = True
 
     if args.vns_conf:
+        global vns_configurations
         vns_configurations = vars(args.vns_conf)
 
     # Set-up output options

--- a/python/fire_rs/planning/benchmark.py
+++ b/python/fire_rs/planning/benchmark.py
@@ -138,7 +138,7 @@ def run_benchmark(scenario, save_directory, instance_name, output_options_plot: 
     geodatadisplay = GeoDataDisplay.pyplot_figure(env.raster.combine(ignitions))
     TrajectoryDisplayExtension(None).extend(geodatadisplay)
 
-    plot_plan_with_background(plan, geodatadisplay, (first_ignition, last_ignition),
+    plot_plan_with_background(pl, geodatadisplay, (first_ignition, last_ignition),
                               output_options_plot)
 
     # Save the picture

--- a/python/fire_rs/planning/benchmark.py
+++ b/python/fire_rs/planning/benchmark.py
@@ -22,70 +22,35 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
 import logging
-import matplotlib
-matplotlib.use('Agg')  # do not require X display to plot figures that are not shown
-import matplotlib.cm
-import matplotlib.colors
-import matplotlib.pyplot
 import numpy as np
+import os
 import random
 import time
 import types
 
 from collections import namedtuple, Sequence
-from itertools import cycle
 from typing import Optional, Tuple, Union
 
-import fire_rs.geodata.display
+import matplotlib
+matplotlib.use('Agg')  # do not require X display to plot figures that are not shown
+import matplotlib.cm
+import matplotlib.colors
+import matplotlib.pyplot
+
 import fire_rs.uav_planning as up
 
+from fire_rs.firemodel import propagation
+from fire_rs.geodata.display import GeoDataDisplay
 from fire_rs.geodata.geo_data import TimedPoint, Area
 from fire_rs.geodata.geo_data import Point as GeoData_Point
+from fire_rs.planning.display import plot_plan_with_background, TrajectoryDisplayExtension
+from fire_rs.planning.planning import FlightConf, Planner, PlanningEnvironment, UAVConf, Waypoint
 
 
 _DBL_MAX = np.finfo(np.float64).max
-
 DISCRETE_ELEVATION_INTERVAL = 100
-
-Waypoint = namedtuple('Waypoint', 'x, y, z, dir')
-
-
-class UAV:
-
-    def __init__(self, max_air_speed: float, max_angular_velocity: float, max_pitch_angle: float,
-                 base_waypoint: 'Union(Waypoint, (float, float, float, float)]'):
-        self.max_air_speed = max_air_speed
-        self.max_angular_velocity = max_angular_velocity
-        self.max_pitch_angle = max_pitch_angle
-        self.base_waypoint = base_waypoint
-
-    def as_cpp(self):
-        return up.UAV(self.max_air_speed, self.max_angular_velocity, self.max_pitch_angle)
-
-    def __repr__(self):
-        return "".join(("UAV(max_air_speed=", repr(self.max_air_speed),
-                        ", max_angular_velocity=", repr(self.max_angular_velocity),
-                        ", base_waypoint=", repr(self.base_waypoint), ")"))
-
-
-class Flight:
-
-    def __init__(self, uav: UAV, start_time: float, max_flight_time: float):
-        assert max_flight_time > 0
-        assert start_time > 0
-        self.uav = uav
-        self.start_time = start_time
-        self.max_flight_time = max_flight_time
-
-    def as_trajectory_config(self):
-        x = self.uav.base_waypoint
-        wp = up.Waypoint(x[0], x[1], x[2], x[3])
-        return up.TrajectoryConfig(self.uav.as_cpp(), wp, wp, self.start_time, self.max_flight_time)
-
-    def __repr__(self):
-        return "".join(("Flight(uav=", repr(self.uav), ", start_time=", repr(self.start_time),
-                        ", max_flight_time=", repr(self.max_flight_time), ")"))
 
 
 class Scenario:
@@ -94,14 +59,14 @@ class Scenario:
                  wind_speed: float,
                  wind_direction: float,
                  ignitions: [TimedPoint],
-                 flights: [Flight]):
-        self.area = area
-        self.wind_speed = wind_speed
-        self.wind_direction = wind_direction
+                 flights: [FlightConf]):
+        self.area = area  # type: Area
+        self.wind_speed = wind_speed  # type: float
+        self.wind_direction = wind_direction  # type: float
         assert len(ignitions) > 0
-        self.ignitions = ignitions
+        self.ignitions = ignitions  # type: [TimedPoint]
         assert len(flights) > 0
-        self.flights = flights
+        self.flights = flights  # type: [FlightConf]
 
         self.time_window_start = np.inf
         self.time_window_end = -np.inf
@@ -115,150 +80,34 @@ class Scenario:
                         ", flights=", repr(self.flights), ")"])
 
 
-class PlanDisplayExtension(fire_rs.geodata.display.DisplayExtension):
-    """Extension to GeoDataDisplay that an observation plan."""
-
-    def __init__(self, plan_trajectory):
-        self.plan_trajectory = plan_trajectory
-
-    def extend(self, geodatadisplay):
-        '''Bounds drawing methods to a GeoDataDisplayInstance.'''
-        geodatadisplay.plan_trajectory = self.plan_trajectory
-        geodatadisplay.draw_waypoints = types.MethodType(PlanDisplayExtension._draw_waypoints_extension, geodatadisplay)
-        geodatadisplay.draw_flighttime_path = types.MethodType(PlanDisplayExtension._draw_flighttime_path_extension, geodatadisplay)
-        geodatadisplay.draw_solid_path = types.MethodType(PlanDisplayExtension._draw_solid_path_extension, geodatadisplay)
-        geodatadisplay.draw_segments = types.MethodType(PlanDisplayExtension._draw_segments_extension, geodatadisplay)
-        geodatadisplay.draw_observedcells = types.MethodType(PlanDisplayExtension._draw_observedcells, geodatadisplay)
-
-    def _draw_waypoints_extension(self, *args, **kwargs):
-        '''Draw path waypoints in a GeoDataDisplay figure.'''
-        color = kwargs.get('color', 'C0')
-        waypoints = self.plan_trajectory.as_waypoints()
-        x = [wp.x for wp in waypoints]
-        y = [wp.y for wp in waypoints]
-        self._drawings.append(self.axis.scatter(x[::2], y[::2], s=7, c=color, marker='D'))
-        self._drawings.append(self.axis.scatter(x[1::2], y[1::2], s=7, c=color, marker='>'))
-
-    def _draw_flighttime_path_extension(self, *args, colorbar_time_range: 'Optional[Tuple[float, float]]' = None,
-                                        **kwargs):
-        '''Draw trajectory in a GeoDataDisplay figure.
-
-        The color of the trajectory will reflect the time taken by the trajectory.
-        Optional argument colorbar_time_range may be a tuple of start and end times in seconds.
-        If the Optional argument with_colorbar is set to True, a color bar will be displayed of the trajectory.
-        '''
-        if len(self.plan_trajectory.segments) < 2:
-            return
-        sampled_waypoints = self.plan_trajectory.sampled(step_size=5)
-        x = [wp.x for wp in sampled_waypoints]
-        y = [wp.y for wp in sampled_waypoints]
-        color_range = np.linspace(self.plan_trajectory.start_time() / 60, self.plan_trajectory.end_time() / 60, len(x))
-        color_norm = matplotlib.colors.Normalize(vmin=color_range[0], vmax=color_range[-1])
-        if colorbar_time_range is not None:
-            color_norm = matplotlib.colors.Normalize(vmin=colorbar_time_range[0]/60, vmax=colorbar_time_range[1]/60)
-        self._drawings.append(self.axis.scatter(x, y, s=1, edgecolors='none', c=color_range,
-                                   norm=color_norm, cmap=matplotlib.cm.gist_rainbow,
-                                                zorder=PlanDisplayExtension.TRAJECTORY_LAYER))
-        if kwargs.get('with_colorbar', False):
-            cb = self._figure.colorbar(self._drawings[-1], ax=self.axis, shrink=0.65, aspect=20)
-            cb.set_label("Flight time [min]")
-            self._colorbars.append(cb)
-
-    def _draw_solid_path_extension(self, *args, **kwargs):
-        '''Draw trajectory in a GeoDataDisplay figure with solid color
-
-        kwargs:
-            color: desired color. Default: C0.
-        '''
-        if len(self.plan_trajectory.segments) < 2:
-            return
-        sampled_waypoints = self.plan_trajectory.sampled(step_size=5)
-        color = kwargs.get('color', 'C0')
-        x = [wp.x for wp in sampled_waypoints]
-        y = [wp.y for wp in sampled_waypoints]
-        self._drawings.append(self.axis.scatter(x, y, s=1, edgecolors='none', c=color,
-                                                zorder=PlanDisplayExtension.TRAJECTORY_LAYER))
-        # TODO: implement legend
-
-    def _draw_segments_extension(self, *args, **kwargs):
-        '''Draw observation segments with start and end points in a GeoDataDisplay figure.'''
-        if len(self.plan_trajectory.segments) < 2:
-            return
-        color = kwargs.get('color', 'C0')
-        segments = self.plan_trajectory.segments[1:-1]
-        start_x = [s.start.x for s in segments]
-        start_y = [s.start.y for s in segments]
-        end_x = [s.end.x for s in segments]
-        end_y = [s.end.y for s in segments]
-
-        self._drawings.append(self.axis.scatter(start_x, start_y, s=10, edgecolor='black', c=color, marker='D',
-                                                zorder=PlanDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
-        self._drawings.append(self.axis.scatter(end_x, end_y, s=10, edgecolor='black', c=color, marker='>',
-                                                zorder=PlanDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
-
-        start_base = self.plan_trajectory.segments[0]
-        finish_base = self.plan_trajectory.segments[-1]
-
-        self._drawings.append(
-            self.axis.scatter(start_base.start.x, start_base.start.y, s=10, edgecolor='black', c=color, marker='o',
-                              zorder=PlanDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
-        self._drawings.append(
-            self.axis.scatter(finish_base.start.x, finish_base.start.y, s=10, edgecolor='black', c=color, marker='o',
-                              zorder=PlanDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
-
-        for i in range(len(segments)):
-            self._drawings.append(self.axis.plot([start_x[i], end_x[i]], [start_y[i], end_y[i]], c=color, linewidth=2,
-                                                 zorder=PlanDisplayExtension.TRAJECTORY_LAYER))
-
-    def _draw_observedcells(self, observations, **kwargs):
-        for ptt in observations:
-            self.axis.scatter(ptt.as_tuple()[0][0], ptt.as_tuple()[0][1], s=4, c=(0., 1., 0., .5),
-                              zorder=PlanDisplayExtension.RASTER_OVERLAY_LAYER, edgecolors='none', marker='s')
-
-
-def plot_plan(plan, geodatadisplay, time_range: 'Optional[Tuple[float, float]]' = None, show=False):
-    colors = cycle(["red", "green", "blue", "black", "magenta"])
-    for traj, color in zip(plan.trajectories(), colors):
-        geodatadisplay.plan_trajectory = traj
-        geodatadisplay.draw_solid_path(color=color)
-        geodatadisplay.draw_segments(color=color)
-    if show:
-        geodatadisplay.axis.get_figure().show()
-
-
 def run_benchmark(scenario, save_directory, instance_name, output_options_plot: dict, output_options_planning: dict,
                   snapshots, vns_name, plot=False):
-    import os
-    import json
-    from fire_rs.firemodel import propagation
 
-    # Fetch scenario environment data
-    env = propagation.Environment(scenario.area, wind_speed=scenario.wind_speed, wind_dir=scenario.wind_direction)
+    # Fetch scenario environment data with additional elevation mode for planning
+    env = PlanningEnvironment(scenario.area, wind_speed=scenario.wind_speed,
+                              wind_dir=scenario.wind_direction,
+                              planning_elevation_mode=output_options_planning['elevation_mode'])
 
     # Propagate fires in the environment
-    prop = propagation.propagate_from_points(env, scenario.ignitions, horizon=scenario.time_window_end + 60 * 10)
+    prop = propagation.propagate_from_points(env, scenario.ignitions,
+                                             horizon=scenario.time_window_end + 60 * 10)
     ignitions = prop.ignitions()
 
     # Propagation was running more time than desired in order to reduce edge effect.
-    # Now we need to filter out-of-range ignition times. Crop range is rounded up to the next 10-minute mark (minus 1).
-    # This makes color bar ranges and fire front contour plots nicer
-    ignitions['ignition'][ignitions['ignition'] > int(scenario.time_window_end / 60. + 5) * 60. - 60] = _DBL_MAX
-
-    # If 'use_elevation' option is True, plan using a 3d environment. If not, use a flat terrain.
-    # This is independent of the output plot, because it can show the real terrain even in flat terrain mode.
-    terrain = env.raster.slice('elevation')
-    if (output_options_planning['use_elevation'] == False):
-        terrain.data['elevation'] = np.zeros_like(terrain.data['elevation'])
+    # Now we need to filter out-of-range ignition times. Crop range is rounded up to the next
+    # 10-minute mark (minus 1). This makes color bar ranges and fire front contour plots nicer
+    ignitions['ignition'][ignitions['ignition'] > \
+                          int(scenario.time_window_end / 60. + 5) * 60. - 60] = _DBL_MAX
 
     # Transform altitude of UAV bases from agl (above ground level) to absolute
     for f in scenario.flights:
-        base_h = terrain["elevation"][terrain.array_index(
-            GeoData_Point(f.uav.base_waypoint[0], f.uav.base_waypoint[1]))]
+        base_h = 100  # If flat, start at the default segment insertion h
+        if output_options_planning['elevation_mode'] != 'flat':
+            base_h = env.raster["elevation"]\
+                [env.raster.array_index((f.base_waypoint[0], f.base_waypoint[1]))]
         # The new WP is (old_x, old_y, old_z + elevation[old_x, old_y], old_dir)
-        f.uav.base_waypoint = Waypoint(
-            f.uav.base_waypoint[0], f.uav.base_waypoint[1], f.uav.base_waypoint[2] + base_h, f.uav.base_waypoint[3])
-    # Retrieve trajectory configurations in as C++ objects
-    flights = [f.as_trajectory_config() for f in scenario.flights]
+        f.base_waypoint = Waypoint(f.base_waypoint[0], f.base_waypoint[1],
+                                   f.base_waypoint[2] + base_h, f.base_waypoint[3])
 
     conf = {
         'min_time': scenario.time_window_start,
@@ -270,9 +119,9 @@ def run_benchmark(scenario, save_directory, instance_name, output_options_plot: 
     }
     conf['vns']['configuration_name'] = vns_name
 
-    # Call the C++ library that calculates the plan
-    res = up.plan_vns(flights, ignitions.as_cpp_raster(), terrain.as_cpp_raster(), json.dumps(conf))
-
+    # Call the planner
+    pl = Planner(env, ignitions, scenario.flights, conf)
+    res = pl.compute_plan()
     plan = res.final_plan()
 
     # Representation of unburned cells using max double is not suitable for display,
@@ -282,37 +131,15 @@ def run_benchmark(scenario, save_directory, instance_name, output_options_plot: 
     first_ignition = np.nanmin(ignitions_nan)
     last_ignition = np.nanmax(ignitions_nan)
 
-    # If 'discrete_elevation_interval' is set, discretize the elevation raster that will be displayed
-    if (output_options_planning['discrete_elevation_interval']):
-        a = env.raster.data['elevation'] + output_options_planning['discrete_elevation_interval']
-        b = np.fmod(env.raster.data['elevation'], output_options_planning['discrete_elevation_interval'])
-        env.raster.data['elevation'] = a-b
+    # Move elevation_planning data to elevation, so we plot the elevation the planner has seen
+    env.raster.data['elevation'] = env.raster.data['elevation_planning']
 
     # Create the geodatadisplay object & extensions that are going to be used
-    geodatadisplay = fire_rs.geodata.display.GeoDataDisplay.pyplot_figure(env.raster.combine(ignitions))
-    PlanDisplayExtension(None).extend(geodatadisplay)
+    geodatadisplay = GeoDataDisplay.pyplot_figure(env.raster.combine(ignitions))
+    TrajectoryDisplayExtension(None).extend(geodatadisplay)
 
-    # Draw background layers
-    for layer in output_options_plot['background']:
-        if layer == 'elevation_shade':
-            geodatadisplay.draw_elevation_shade(with_colorbar=output_options_plot.get('colorbar', True))
-        elif layer == 'ignition_shade':
-            geodatadisplay.draw_ignition_shade(with_colorbar=output_options_plot.get('colorbar', True))
-        elif layer == 'observedcells':
-            geodatadisplay.draw_observedcells(res.final_plan().observations())
-        elif layer == 'ignition_contour':
-            try:
-                geodatadisplay.draw_ignition_contour(with_labels=True)
-            except ValueError as e:
-                logging.warn(e)
-        elif layer == 'wind_quiver':
-            geodatadisplay.draw_wind_quiver()
-
-    for i, t in enumerate(res.final_plan().trajectories()):
-        print("traj #{} duration: {} / {}".format(i, t.duration(), t.conf.max_flight_time))
-
-    # Plot the final plan
-    plot_plan(res.final_plan(), geodatadisplay, time_range=(first_ignition, last_ignition), show=True)
+    plot_plan_with_background(plan, geodatadisplay, (first_ignition, last_ignition),
+                              output_options_plot)
 
     # Save the picture
     print("saving as: " + str(os.path.join(
@@ -321,6 +148,10 @@ def run_benchmark(scenario, save_directory, instance_name, output_options_plot: 
     geodatadisplay.axis.get_figure().savefig(os.path.join(
         save_directory, instance_name + "." + str(output_options_plot.get('format', 'png'))),
         dpi=output_options_plot.get('dpi', 150), bbox_inches='tight')
+
+    # Log planned trajectories metadata
+    for i, t in enumerate(plan.trajectories()):
+        logging.info("traj #{} duration: {} / {}".format(i, t.duration(), t.conf.max_flight_time))
 
     # save metadata to file
     with open(os.path.join(save_directory, instance_name+".json"), "w") as metadata_file:
@@ -335,20 +166,8 @@ def run_benchmark(scenario, save_directory, instance_name, output_options_plot: 
 
     # If intermediate plans are available, save them
     for i, i_plan in enumerate(res.intermediate_plans):
-        geodatadisplay = fire_rs.geodata.display.GeoDataDisplay.pyplot_figure(env.raster.combine(ignitions))
-        PlanDisplayExtension(None).extend(geodatadisplay)
-        for layer in output_options_plot['background']:
-            if layer == 'elevation_shade':
-                geodatadisplay.draw_elevation_shade(with_colorbar=output_options_plot.get('colorbar', True))
-            elif layer == 'ignition_shade':
-                geodatadisplay.draw_ignition_shade(with_colorbar=output_options_plot.get('colorbar', True))
-            elif layer == 'observedcells':
-                geodatadisplay.draw_observedcells(i_plan.observations())
-            elif layer == 'ignition_contour':
-                geodatadisplay.draw_ignition_contour(with_labels=True)
-            elif layer == 'wind_quiver':
-                geodatadisplay.draw_wind_quiver()
-        plot_plan(i_plan, geodatadisplay, time_range=(first_ignition, last_ignition), show=True)
+        plot_plan_with_background(i_plan, geodatadisplay, (first_ignition, last_ignition),
+                                  output_options_plot)
 
         i_plan_dir = os.path.join(save_directory, instance_name)
         if not os.path.exists(i_plan_dir):
@@ -388,10 +207,10 @@ def generate_scenario_newsletter():
     num_flights = 1
     flights = []
     for i in range(num_flights):
-        uav = UAV(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, random.choice(uav_bases))
         uav_start = start + 3000
         max_flight_time = 450
-        flights.append(Flight(uav, uav_start, max_flight_time))
+        uav = UAVConf(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, max_flight_time)
+        flights.append(FlightConf(uav, uav_start, random.choice(uav_bases)))
 
     scenario = Scenario(((area.xmin, area.xmax), (area.ymin, area.ymax)),
                         wind_speed, wind_dir, ignitions, flights)
@@ -421,10 +240,10 @@ def generate_scenario_singlefire_singleuav_3d():
     num_flights = 1
     flights = []
     for i in range(num_flights):
-        uav = UAV(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, random.choice(uav_bases))
         uav_start = random.uniform(start + 2500, start + 7500.)
         max_flight_time = random.uniform(1000, 1500)
-        flights.append(Flight(uav, uav_start, max_flight_time))
+        uav = UAVConf(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, max_flight_time)
+        flights.append(FlightConf(uav, uav_start, random.choice(uav_bases)))
 
     scenario = Scenario(((area.xmin, area.xmax), (area.ymin, area.ymax)),
                         wind_speed, wind_dir, ignitions, flights)
@@ -455,10 +274,10 @@ def generate_scenario_singlefire_singleuav_shortrange():
     num_flights = 1
     flights = []
     for i in range(num_flights):
-        uav = UAV(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, random.choice(uav_bases))
         uav_start = random.uniform(start + 5000, start + 7000.)
         max_flight_time = random.uniform(500, 1000)
-        flights.append(Flight(uav, uav_start, max_flight_time))
+        uav = UAVConf(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, max_flight_time)
+        flights.append(FlightConf(uav, uav_start, random.choice(uav_bases)))
 
     scenario = Scenario(((area.xmin, area.xmax), (area.ymin, area.ymax)),
                         wind_speed, wind_dir, ignitions, flights)
@@ -471,7 +290,7 @@ def generate_scenario_singlefire_singleuav():
     uav_speed = 18.  # m/s
     uav_max_pitch_angle = 6. / 180. * np.pi
     uav_max_turn_rate = 32. * np.pi / 180 / 2  # Consider a more conservative turn rate
-    uav_bases = [Waypoint(area.xmin +100, area.ymin+100, 0)]
+    uav_bases = [Waypoint(area.xmin + 100, area.ymin + 100, 0)]
 
     wind_speed = 15.
     wind_dir = 0.
@@ -487,10 +306,10 @@ def generate_scenario_singlefire_singleuav():
     num_flights = 1
     flights = []
     for i in range(num_flights):
-        uav = UAV(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, random.choice(uav_bases))
         uav_start = random.uniform(start, start + 4000.)
         max_flight_time = random.uniform(1000, 1500)
-        flights.append(Flight(uav, uav_start, max_flight_time))
+        uav = UAVConf(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, max_flight_time)
+        flights.append(FlightConf(uav, uav_start, random.choice(uav_bases)))
 
     scenario = Scenario(((area.xmin, area.xmax), (area.ymin, area.ymax)),
                         wind_speed, wind_dir, ignitions, flights)
@@ -524,10 +343,10 @@ def generate_scenario():
     num_flights = random.randint(1, 3)
     flights = []
     for i in range(num_flights):
-        uav = UAV(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, random.choice(uav_bases))
         uav_start = random.uniform(start, start + 4000.)
         max_flight_time = random.uniform(500, 1200)
-        flights.append(Flight(uav, uav_start, max_flight_time))
+        uav = UAVConf(uav_speed, uav_max_turn_rate, uav_max_pitch_angle, max_flight_time)
+        flights.append(FlightConf(uav, uav_start, random.choice(uav_bases)))
 
     scenario = Scenario(((area.xmin, area.xmax), (area.ymin, area.ymax)),
                         wind_speed, wind_dir, ignitions, flights)
@@ -690,9 +509,9 @@ def main():
     output_options['plot']['colorbar'] = args.colorbar
     output_options['plot']['dpi'] = args.dpi
     output_options['plot']['size'] = args.size
-    output_options['planning']['use_elevation'] = False if args.elevation == "flat" else True
+    output_options['planning']['elevation_mode'] = args.elevation
     output_options['planning']['discrete_elevation_interval'] = \
-        DISCRETE_ELEVATION_INTERVAL if args.elevation == "discrete" else 0
+        DISCRETE_ELEVATION_INTERVAL if args.elevation == 'discrete' else 0
 
     # benchmark folder handling
     benchmark_name = args.name

--- a/python/fire_rs/planning/display.py
+++ b/python/fire_rs/planning/display.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2017, CNRS-LAAS
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import types
+
+from itertools import cycle
+
+import matplotlib.cm
+import matplotlib.colors
+import matplotlib.pyplot
+
+import fire_rs.geodata.display as gdd
+
+
+class TrajectoryDisplayExtension(gdd.DisplayExtension):
+    """Extension to GeoDataDisplay that an observation trajectories."""
+
+    def __init__(self, plan_trajectory):
+        self.plan_trajectory = plan_trajectory
+
+    def extend(self, geodatadisplay):
+        '''Bounds drawing methods to a GeoDataDisplayInstance.'''
+        geodatadisplay.plan_trajectory = self.plan_trajectory
+        geodatadisplay.draw_waypoints = types.MethodType(
+            TrajectoryDisplayExtension._draw_waypoints_extension, geodatadisplay)
+        geodatadisplay.draw_flighttime_path = types.MethodType(
+            TrajectoryDisplayExtension._draw_flighttime_path_extension, geodatadisplay)
+        geodatadisplay.draw_solid_path = types.MethodType(
+            TrajectoryDisplayExtension._draw_solid_path_extension, geodatadisplay)
+        geodatadisplay.draw_segments = types.MethodType(
+            TrajectoryDisplayExtension._draw_segments_extension, geodatadisplay)
+        geodatadisplay.draw_observedcells = types.MethodType(
+            TrajectoryDisplayExtension._draw_observedcells, geodatadisplay)
+
+    def _draw_waypoints_extension(self, *args, **kwargs):
+        '''Draw path waypoints in a GeoDataDisplay figure.'''
+        color = kwargs.get('color', 'C0')
+        waypoints = self.plan_trajectory.as_waypoints()
+        x = [wp.x for wp in waypoints]
+        y = [wp.y for wp in waypoints]
+        self._drawings.append(self.axis.scatter(x[::2], y[::2], s=7, c=color, marker='D'))
+        self._drawings.append(self.axis.scatter(x[1::2], y[1::2], s=7, c=color, marker='>'))
+
+    def _draw_flighttime_path_extension(self, *args, colorbar_time_range: 'Optional[Tuple[float, float]]' = None,
+                                        **kwargs):
+        '''Draw trajectory in a GeoDataDisplay figure.
+
+        The color of the trajectory will reflect the time taken by the trajectory.
+        Optional argument colorbar_time_range may be a tuple of start and end times in seconds.
+        If the Optional argument with_colorbar is set to True, a color bar will be displayed of the trajectory.
+        '''
+        if len(self.plan_trajectory.segments) < 2:
+            return
+        sampled_waypoints = self.plan_trajectory.sampled(step_size=5)
+        x = [wp.x for wp in sampled_waypoints]
+        y = [wp.y for wp in sampled_waypoints]
+        color_range = np.linspace(self.plan_trajectory.start_time() / 60, self.plan_trajectory.end_time() / 60, len(x))
+        color_norm = matplotlib.colors.Normalize(vmin=color_range[0], vmax=color_range[-1])
+        if colorbar_time_range is not None:
+            color_norm = matplotlib.colors.Normalize(vmin=colorbar_time_range[0]/60, vmax=colorbar_time_range[1]/60)
+        self._drawings.append(self.axis.scatter(x, y, s=1, edgecolors='none', c=color_range,
+                                   norm=color_norm, cmap=matplotlib.cm.gist_rainbow,
+                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_LAYER))
+        if kwargs.get('with_colorbar', False):
+            cb = self._figure.colorbar(self._drawings[-1], ax=self.axis, shrink=0.65, aspect=20)
+            cb.set_label("Flight time [min]")
+            self._colorbars.append(cb)
+
+    def _draw_solid_path_extension(self, *args, **kwargs):
+        '''Draw trajectory in a GeoDataDisplay figure with solid color
+
+        kwargs:
+            color: desired color. Default: C0.
+        '''
+        if len(self.plan_trajectory.segments) < 2:
+            return
+        sampled_waypoints = self.plan_trajectory.sampled(step_size=5)
+        color = kwargs.get('color', 'C0')
+        x = [wp.x for wp in sampled_waypoints]
+        y = [wp.y for wp in sampled_waypoints]
+        self._drawings.append(self.axis.scatter(x, y, s=1, edgecolors='none', c=color,
+                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_LAYER))
+        # TODO: implement legend
+
+    def _draw_segments_extension(self, *args, **kwargs):
+        '''Draw observation segments with start and end points in a GeoDataDisplay figure.'''
+        if len(self.plan_trajectory.segments) < 2:
+            return
+        color = kwargs.get('color', 'C0')
+        segments = self.plan_trajectory.segments[1:-1]
+        start_x = [s.start.x for s in segments]
+        start_y = [s.start.y for s in segments]
+        end_x = [s.end.x for s in segments]
+        end_y = [s.end.y for s in segments]
+
+        self._drawings.append(self.axis.scatter(start_x, start_y, s=10, edgecolor='black', c=color, marker='D',
+                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+        self._drawings.append(self.axis.scatter(end_x, end_y, s=10, edgecolor='black', c=color, marker='>',
+                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+
+        start_base = self.plan_trajectory.segments[0]
+        finish_base = self.plan_trajectory.segments[-1]
+
+        self._drawings.append(
+            self.axis.scatter(start_base.start.x, start_base.start.y, s=10, edgecolor='black', c=color, marker='o',
+                              zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+        self._drawings.append(
+            self.axis.scatter(finish_base.start.x, finish_base.start.y, s=10, edgecolor='black', c=color, marker='o',
+                              zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+
+        for i in range(len(segments)):
+            self._drawings.append(self.axis.plot([start_x[i], end_x[i]], [start_y[i], end_y[i]], c=color, linewidth=2,
+                                                 zorder=TrajectoryDisplayExtension.TRAJECTORY_LAYER))
+
+    def _draw_observedcells(self, observations, **kwargs):
+        for ptt in observations:
+            self.axis.scatter(ptt.as_tuple()[0][0], ptt.as_tuple()[0][1], s=4, c=(0., 1., 0., .5),
+                              zorder=TrajectoryDisplayExtension.RASTER_OVERLAY_LAYER, edgecolors='none', marker='s')
+
+
+def plot_plan_trajectories(plan, geodatadisplay, time_range: 'Optional[Tuple[float, float]]' = None, show=False):
+    """Plot the trajectories of a plan."""
+    colors = cycle(["red", "green", "blue", "black", "magenta"])
+    for traj, color in zip(plan.trajectories(), colors):
+        geodatadisplay.plan_trajectory = traj
+        geodatadisplay.draw_solid_path(color=color)
+        geodatadisplay.draw_segments(color=color)
+    if show:
+        geodatadisplay.axis.get_figure().show()
+
+
+def plot_plan_with_background(plan, geodatadisplay, time_range, output_options_plot):
+    """Plot a plan trajectories with background geographic information in a geodata display."""
+    # Draw background layers
+    for layer in output_options_plot['background']:
+        if layer == 'elevation_shade':
+            geodatadisplay.draw_elevation_shade(
+                with_colorbar=output_options_plot.get('colorbar', True))
+        elif layer == 'ignition_shade':
+            geodatadisplay.draw_ignition_shade(
+                with_colorbar=output_options_plot.get('colorbar', True))
+        elif layer == 'observedcells':
+            geodatadisplay.draw_observedcells(plan.observations())
+        elif layer == 'ignition_contour':
+            try:
+                geodatadisplay.draw_ignition_contour(with_labels=True)
+            except ValueError as e:
+                logging.warning(e)
+        elif layer == 'wind_quiver':
+            geodatadisplay.draw_wind_quiver()
+
+    # Plot the plan
+    plot_plan_trajectories(plan, geodatadisplay, time_range=time_range, show=True)

--- a/python/fire_rs/planning/display.py
+++ b/python/fire_rs/planning/display.py
@@ -82,7 +82,7 @@ class TrajectoryDisplayExtension(gdd.DisplayExtension):
             color_norm = matplotlib.colors.Normalize(vmin=colorbar_time_range[0]/60, vmax=colorbar_time_range[1]/60)
         self._drawings.append(self.axis.scatter(x, y, s=1, edgecolors='none', c=color_range,
                                    norm=color_norm, cmap=matplotlib.cm.gist_rainbow,
-                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_LAYER))
+                                                zorder=TrajectoryDisplayExtension.FOREGROUND_LAYER))
         if kwargs.get('with_colorbar', False):
             cb = self._figure.colorbar(self._drawings[-1], ax=self.axis, shrink=0.65, aspect=20)
             cb.set_label("Flight time [min]")
@@ -101,7 +101,7 @@ class TrajectoryDisplayExtension(gdd.DisplayExtension):
         x = [wp.x for wp in sampled_waypoints]
         y = [wp.y for wp in sampled_waypoints]
         self._drawings.append(self.axis.scatter(x, y, s=1, edgecolors='none', c=color,
-                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_LAYER))
+                                                zorder=TrajectoryDisplayExtension.FOREGROUND_LAYER))
         # TODO: implement legend
 
     def _draw_segments_extension(self, *args, **kwargs):
@@ -116,28 +116,28 @@ class TrajectoryDisplayExtension(gdd.DisplayExtension):
         end_y = [s.end.y for s in segments]
 
         self._drawings.append(self.axis.scatter(start_x, start_y, s=10, edgecolor='black', c=color, marker='D',
-                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+                                                zorder=TrajectoryDisplayExtension.FOREGROUND_OVERLAY_LAYER))
         self._drawings.append(self.axis.scatter(end_x, end_y, s=10, edgecolor='black', c=color, marker='>',
-                                                zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+                                                zorder=TrajectoryDisplayExtension.FOREGROUND_OVERLAY_LAYER))
 
         start_base = self.plan_trajectory.segments[0]
         finish_base = self.plan_trajectory.segments[-1]
 
         self._drawings.append(
             self.axis.scatter(start_base.start.x, start_base.start.y, s=10, edgecolor='black', c=color, marker='o',
-                              zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+                              zorder=TrajectoryDisplayExtension.FOREGROUND_OVERLAY_LAYER))
         self._drawings.append(
             self.axis.scatter(finish_base.start.x, finish_base.start.y, s=10, edgecolor='black', c=color, marker='o',
-                              zorder=TrajectoryDisplayExtension.TRAJECTORY_OVERLAY_LAYER))
+                              zorder=TrajectoryDisplayExtension.FOREGROUND_OVERLAY_LAYER))
 
         for i in range(len(segments)):
             self._drawings.append(self.axis.plot([start_x[i], end_x[i]], [start_y[i], end_y[i]], c=color, linewidth=2,
-                                                 zorder=TrajectoryDisplayExtension.TRAJECTORY_LAYER))
+                                                 zorder=TrajectoryDisplayExtension.FOREGROUND_LAYER))
 
     def _draw_observedcells(self, observations, **kwargs):
         for ptt in observations:
             self.axis.scatter(ptt.as_tuple()[0][0], ptt.as_tuple()[0][1], s=4, c=(0., 1., 0., .5),
-                              zorder=TrajectoryDisplayExtension.RASTER_OVERLAY_LAYER, edgecolors='none', marker='s')
+                              zorder=TrajectoryDisplayExtension.BACKGROUND_OVERLAY_LAYER, edgecolors='none', marker='s')
 
 
 def plot_plan_trajectories(plan, geodatadisplay, time_range: 'Optional[Tuple[float, float]]' = None, show=False):

--- a/python/fire_rs/planning/display.py
+++ b/python/fire_rs/planning/display.py
@@ -147,8 +147,8 @@ class TrajectoryDisplayExtension(gdd.DisplayExtension):
                               zorder=TrajectoryDisplayExtension.BACKGROUND_OVERLAY_LAYER,
                               edgecolors='none', marker='s')
 
-    def _draw_observation_map(self, observation_map: 'GeoData', layer='ignition'):
-        o_map = np.array(observation_map['ignition'])
+    def _draw_observation_map(self, observation_map: 'GeoData', layer='observed_ignition'):
+        o_map = np.array(observation_map[layer])
         o_map[~np.isnan(o_map)] = 1
 
         # define the colors

--- a/python/fire_rs/planning/planning.py
+++ b/python/fire_rs/planning/planning.py
@@ -175,11 +175,11 @@ class Planner:
     def flights(self):
         return self._flights
 
-    def observed_firemap(self, time_window=None) -> 'GeoData':
-        observed_firemap = GeoData.full_like(self._firemap, np.nan)  # type: GeoData
+    def observed_firemap(self, time_window=None, layer_name='observed_ignition') -> 'GeoData':
+        observed_firemap = self._firemap.clone(fill_value=np.nan, dtype=[(layer_name,'float64')])
         for (p, t) in self.observed_cells(time_window):
             array_pos = observed_firemap.array_index(p)
-            observed_firemap['ignition'][array_pos] = t
+            observed_firemap[layer_name][array_pos] = t
         return observed_firemap
 
     @property

--- a/python/fire_rs/planning/planning.py
+++ b/python/fire_rs/planning/planning.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2017, CNRS-LAAS
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import logging
+import types
+from collections import namedtuple
+from typing import Optional, Tuple, Union
+
+import numpy as np
+
+import fire_rs.uav_planning as up
+from fire_rs.firemodel.propagation import Environment, FirePropagation
+from fire_rs.geodata.geo_data import Area, GeoData, TimedPoint
+
+
+class Waypoint(namedtuple('Waypoint', 'x, y, z, dir')):
+    __slots__ = ()
+
+    def as_cpp(self):
+        return up.Waypoint(self.x, self.y, self.z, self.dir)
+
+
+class UAVConf:
+
+    def __init__(self, max_air_speed: float, max_angular_velocity: float, max_pitch_angle: float,
+                 max_flight_time: float):
+        self.max_air_speed = max_air_speed  # type: float
+        self.max_angular_velocity = max_angular_velocity  # type: float
+        self.max_pitch_angle = max_pitch_angle  # type: float
+        self.max_flight_time = max_flight_time  # type: float
+
+    @classmethod
+    def X8(cls):
+        return cls(max_air_speed=18., max_angular_velocity=32./180.*np.pi,
+                   max_pitch_angle=6./180.*np.pi, max_flight_time=3000.)
+
+    def as_cpp(self):
+        return up.UAV(self.max_air_speed, self.max_angular_velocity, self.max_pitch_angle)
+
+    def __repr__(self):
+        return "".join(("UAVConf(max_air_speed=", repr(self.max_air_speed),
+                        ", max_angular_velocity=", repr(self.max_angular_velocity),
+                        ", max_pitch_angle=", repr(self.max_pitch_angle),
+                        ", max_flight_time=", repr(self.max_flight_time), ")"))
+
+
+class FlightConf:
+
+    def __init__(self, uav: UAVConf, start_time: float, base_waypoint: 'Waypoint',
+                 finalbase_waypoint: 'Optional[Waypoint]' = None):
+        assert start_time > 0
+        self.uav = uav  # type: UAVConf
+        self.base_waypoint = base_waypoint  # type: Waypoint
+        # type: Optional[Waypoint]
+        self.finalbase_waypoint = finalbase_waypoint if finalbase_waypoint else base_waypoint
+        self.start_time = start_time  # type: float
+
+    @property
+    def max_flight_time(self):
+        return self.uav.max_flight_time
+
+    def as_cpp(self):
+        return up.TrajectoryConfig(self.uav.as_cpp(), self.base_waypoint.as_cpp(),
+                                   self.finalbase_waypoint.as_cpp(), self.start_time,
+                                   self.uav.max_flight_time)
+
+    def __repr__(self):
+        return "".join(("FlightConf(uav=", repr(self.uav),
+                        ", base_waypoint=", repr(self.base_waypoint),
+                        ", start_time=", repr(self.start_time), ")"))
+
+
+class PlanningEnvironment(Environment):
+    """Propagation environment with optional discrete elevation only for planning """
+
+    def __init__(self, area, wind_speed, wind_dir, planning_elevation_mode: 'str'='dem',
+                 discrete_elevation_interval:'int'=0):
+        super().__init__(area, wind_speed, wind_dir)
+
+        self.planning_elevation_mode = planning_elevation_mode
+        self.discrete_elevation_interval = discrete_elevation_interval
+
+        elev_planning = None
+
+        if self.planning_elevation_mode == 'flat':
+            elev_planning = self.raster.clone(fill_value=0.,
+                                              dtype=[('elevation_planning', 'float64')])
+        elif self.planning_elevation_mode == 'dem':
+            elev_planning = self.raster.clone(data_array=self.raster["elevation"],
+                                              dtype=[('elevation_planning', 'float64')])
+        elif self.planning_elevation_mode == 'discrete':
+            a = self.raster.data['elevation'] + self.discrete_elevation_interval
+            b = np.fmod(self.raster.data['elevation'], self.discrete_elevation_interval)
+            self.raster.data['elevation'] = a - b
+        else:
+            elev_planning = self.raster.clone(data_array=self.raster["elevation"],
+                                              dtype=[('elevation_planning', 'float64')])
+            raise ValueError("".join(["Wrong planning_elevation_mode '",
+                                      self.planning_elevation_mode, "'"]))
+
+        self.raster = self.raster.combine(elev_planning)
+
+
+class Planner:
+    def __init__(self, env: 'PlanningEnvironment', firemap: 'GeoData', flights: '[FlightConf]',
+                 planning_conf: 'dict'):
+        assert "ignition" in firemap.layers
+        self._env = env  # type: PlanningEnvironment
+        self._firemap = firemap  # type: GeoData
+        self._flights = flights[:]  # type: [FlightConf]
+        self._observed_firemap = GeoData.zeros_like(self._firemap)  # type: GeoData
+        self._cpp_planning_conf = planning_conf  # type: dict
+
+        self._searchresult = None  # type: Optional(up.SearchResult)
+
+    def compute_plan(self, t_start=0.0) -> 'up.SearchResult':
+        # Retrieve trajectory configurations in as C++ objects
+        cpp_flights = [f.as_cpp() for f in self._flights]
+
+        # Call the C++ library that calculates the plan
+        res = up.plan_vns(cpp_flights,
+                          self._firemap.as_cpp_raster(),
+                          self._env.raster.slice('elevation_planning').as_cpp_raster(),
+                          json.dumps(self._cpp_planning_conf))
+        self._searchresult = res
+        print(res.final_plan().trajectories()[0].segments)
+        return res
+
+    @property
+    def environment(self) -> 'Environment':
+        return self._env
+
+    @property
+    def firemap(self) -> 'GeoData':
+        return self._firemap
+
+    @firemap.setter
+    def firemap(self, value: 'GeoData'):
+        assert self._firemap.x_offset == value.x_offset
+        assert self._firemap.y_offset == value.y_offset
+        assert self._firemap.cell_width == value.cell_width
+        assert self._firemap.cell_height == value.cell_height
+
+        self._firemap._firemap = value
+
+    @property
+    def flights(self):
+        return self._flights
+
+    @property
+    def observed_firemap(self):
+        return self._observed_firemap
+
+    @property
+    def search_result(self):
+        return self._searchresult
+
+
+class PlanningManager:
+    def __init__(self, planner: Planner):
+        self._planner = planner  # type: Planner
+
+    def update_area_wind(self, wind_velocity, wind_direction):
+        self._planner.environment.update_area_wind(wind_velocity, wind_direction)
+
+    def update_firemap(self, firemap: GeoData):
+        self._planner.firemap = firemap
+
+    def replan(self):
+        """Replan should run Planner.compute_plan with the updated information."""
+        pass
+
+
+if __name__ == '__main__':
+    import os
+    import json
+    from fire_rs.firemodel import propagation
+    from fire_rs.geodata.geo_data import TimedPoint
+
+    # Geographic environment (elevation, landcover, wind...)
+    area = ((480060.0, 485060.0), (6210074.0, 6215074.0))
+    env = PlanningEnvironment(area, wind_speed=5., wind_dir=0., planning_elevation_mode='dem')
+
+    # Fire applied to the previous environment
+    ignition_point = TimedPoint(area[0][0] + 1000.0, area[1][0] + 2000.0, 0)
+    fire = propagation.propagate_from_points(env, ignition_point, 9000)
+
+    # Configure some flight
+    base_wp = Waypoint(area[0][0]+100., area[1][0]+100., 100., 0.)
+    start_t = 30 * 60  # 30 minutes after the ignition
+    fgconf = FlightConf(UAVConf.X8(), start_t, base_wp)
+
+    # Write down the desired VNS configuration
+    conf_vns = {
+        "base": {
+            "max_restarts": 5,
+            "neighborhoods": [
+                {"name": "dubins-opt",
+                 "max_trials": 10,
+                 "generators": [
+                     {"name": "MeanOrientationChangeGenerator"},
+                     {"name": "RandomOrientationChangeGenerator"},
+                     {"name": "FlipOrientationChangeGenerator"}]},
+                {"name": "one-insert",
+                 "max_trials": 50,
+                 "select_arbitrary_trajectory": False,
+                 "select_arbitrary_position": False}
+            ]
+        }
+    }
+
+    conf = {
+        'min_time': fgconf.start_time,
+        'max_time': fgconf.start_time+fgconf.uav.max_flight_time,
+        'save_every': 0,
+        'save_improvements': False,
+        'discrete_elevation_interval': 0,
+        'vns': conf_vns['base']
+    }
+    conf['vns']['configuration_name'] = 'base'
+
+    # Instantiate the planner
+    pl = Planner(env, fire.ignitions(), [fgconf], conf)
+    pl.compute_plan()
+    print(pl.search_result)

--- a/python/fire_rs/planning/planning.py
+++ b/python/fire_rs/planning/planning.py
@@ -264,5 +264,10 @@ if __name__ == '__main__':
 
     fm = pl.observed_firemap()
 
+    import matplotlib
+    import fire_rs.geodata.display
+    gdd = fire_rs.geodata.display.GeoDataDisplay(*fire_rs.geodata.display.get_pyplot_figure_and_axis(), fm)
+    TrajectoryDisplayExtension(None).extend(gdd)
+    gdd.draw_observation_map(fm)
     print(pl.search_result)
 


### PR DESCRIPTION
Right now, the only way to launch the planning algorithm is through the benchmark script, that is getting quite large.  I moved to other files most of the functionality to launch the VNS planning and to display the results. This way, interface and logic are kept separate.

Merging this PR is required for using SAOP in other contexts than benchmarking. In the near future, we should be able to re-plan and to communicate with a UAV ground control station in order to "close the loop"

Note: The command line interface of benchmark.py is the same as before. This PR only reorders what is inside.
